### PR TITLE
overlay: Disable SystemUI anti-falsing on lockscreen

### DIFF
--- a/overlay/common/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/common/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -22,8 +22,8 @@
 <resources>
     <!-- Control whether status bar should distinguish HSPA data icon form UMTS data icon on devices -->
     <bool name="config_hspa_data_distinguishable">true</bool>
-
-    <!-- Should "4G" be shown instead of "LTE" when the network is NETWORK_TYPE_LTE? -->
+	
+	    <!-- Should "4G" be shown instead of "LTE" when the network is NETWORK_TYPE_LTE? -->
     <bool name="config_show4GForLTE">false</bool>
 
     <bool name="quick_settings_show_full_alarm">true</bool>
@@ -31,5 +31,9 @@
     <!-- The duration in seconds to wait before the dismiss buttons are shown. -->
     <integer name="recents_task_bar_dismiss_delay_seconds">0</integer>
 
+    <!-- If true, enable the advance anti-falsing classifier on the lockscreen. On some devices it
+         does not work well, particularly with noisy touchscreens. Note that disabling it may
+         increase the rate of unintentional unlocks. -->
+    <bool name="config_lockscreenAntiFalsingClassifierEnabled">false</bool>
 </resources>
 


### PR DESCRIPTION
 * The anti-falsing implementation from HumanInteractionClassifier
    regularly prevents easy swipe to unlock or to pattern / pin
    on the keyguard lockscreen, requiring multiple attempts
    until accepted due to a hardcoded evaluation (5.0f)
    while normal usage shows better results without it

 * Another solved situation is remote device access like
    Vysor or TeamViewer where the device is almost impossible
    to swipe properly from a computer client

Change-Id: I1caf603bc6a3bf7794af724b8e48a9ebb96da971